### PR TITLE
Adds opt-in to SignalException workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,12 @@ By default, the TTL drivers will log an INFO heart beat every ~5 seconds. You ca
 LUMEN_PROC_HEARTBEAT=disabled
 ```
 
+You may enable `SignalException` to be thrown asynchronously when a signal is processed, this will happen from wherever your normal code is being executed and gives you a chance to clean things up gracefully while still responding immediately to signals (or ignore them if appropriate.)
+
+```bash
+LUMEN_PROC_THROW_SIGNAL_EXCEPTION=enabled
+```
+
 
 ## Available Drivers
 

--- a/src/Driver/KeepAliveProcessDriver.php
+++ b/src/Driver/KeepAliveProcessDriver.php
@@ -25,7 +25,9 @@ class KeepAliveProcessDriver implements ProcessControl {
 	protected $interrupt = false;
 
 	public function __construct(SignalHandler $signalHandler) {
-		$this->startTime = microtime(true);
+		$this->startTime                = microtime(true);
+		$this->throwSignalExceptions    = env('LUMEN_PROC_THROW_SIGNAL_EXCEPTION', 'disabled') == 'enabled';
+
 		$signalHandler->bind($this, 'sigHandle');
 	}
 
@@ -51,9 +53,5 @@ class KeepAliveProcessDriver implements ProcessControl {
 		if ($this->throwSignalExceptions) {
 			throw new SignalException($signo, $info);
 		}
-	}
-
-	public function throwSignalExceptions(bool $throw = true) : void {
-		$this->throwSignalExceptions = $throw;
 	}
 }

--- a/src/Driver/KeepAliveProcessDriver.php
+++ b/src/Driver/KeepAliveProcessDriver.php
@@ -2,51 +2,58 @@
 
 namespace Resgen\Common\Proc\Driver;
 
-use Resgen\Common\Proc\ProcessControl;
 use Resgen\Common\Proc\EscapeProcessException;
+use Resgen\Common\Proc\ProcessControl;
+use Resgen\Common\Proc\SignalException;
 
-class KeepAliveProcessDriver implements ProcessControl
-{
-    use Logs;
+class KeepAliveProcessDriver implements ProcessControl {
+	use Logs;
 
-    /** @var int */
-    protected $lastMsgTime;
+	/** @var bool If true, a SignalException will be thrown when the signal is handled */
+	protected $throwSignalExceptions = false;
 
-    /** @var int */
-    protected $startTime;
+	/** @var int */
+	protected $lastMsgTime;
 
-    /** @var int */
-    protected $timeSpentProcessing = 0;
+	/** @var int */
+	protected $startTime;
 
-    /** @var bool */
-    protected $interrupt = false;
+	/** @var int */
+	protected $timeSpentProcessing = 0;
 
-    public function __construct(SignalHandler $signalHandler)
-    {
-        $this->startTime  = microtime(true);
-        $signalHandler->bind($this, 'sigHandle');
-    }
+	/** @var bool */
+	protected $interrupt = false;
 
-    public function check(): void
-    {
-        // processing time in seconds
-        $this->timeSpentProcessing = (microtime(true) - $this->startTime);
+	public function __construct(SignalHandler $signalHandler) {
+		$this->startTime = microtime(true);
+		$signalHandler->bind($this, 'sigHandle');
+	}
 
-        if ($this->interrupt) {
-            throw new EscapeProcessException('Interrupt signal processed.');
-        }
+	public function check() : void {
+		// processing time in seconds
+		$this->timeSpentProcessing = (microtime(true) - $this->startTime);
 
-        // Heart beat log every ~5secs
-        if (microtime(true) - $this->lastMsgTime > 5) {
-            $this->heartBeat()->info(round($this->timeSpentProcessing).' seconds spent processing');
-            $this->lastMsgTime = microtime(true);
-        }
-    }
+		if ($this->interrupt) {
+			throw new EscapeProcessException('Interrupt signal processed.');
+		}
 
-    public function sigHandle()
-    {
-        $this->log()->info('Interrupt signal recieved. Starting graceful shutdown.');
-        $this->interrupt = true;
-    }
+		// Heart beat log every ~5secs
+		if (microtime(true) - $this->lastMsgTime > 5) {
+			$this->heartBeat()->info(round($this->timeSpentProcessing) . ' seconds spent processing');
+			$this->lastMsgTime = microtime(true);
+		}
+	}
 
+	public function sigHandle(int $signo, mixed $info) {
+		$this->log()->info('Interrupt signal recieved. Starting graceful shutdown.');
+		$this->interrupt = true;
+
+		if ($this->throwSignalExceptions) {
+			throw new SignalException($signo, $info);
+		}
+	}
+
+	public function throwSignalExceptions(bool $throw = true) : void {
+		$this->throwSignalExceptions = $throw;
+	}
 }

--- a/src/Driver/RunOnceProcessDriver.php
+++ b/src/Driver/RunOnceProcessDriver.php
@@ -2,15 +2,14 @@
 
 namespace Resgen\Common\Proc\Driver;
 
-use Resgen\Common\Proc\ProcessControl;
 use Resgen\Common\Proc\EscapeProcessException;
+use Resgen\Common\Proc\ProcessControl;
 
-class RunOnceProcessDriver implements ProcessControl
-{
+class RunOnceProcessDriver implements ProcessControl {
 
-    public function check(): void
-    {
-        throw new EscapeProcessException('Run once proc control driver configured.');
-    }
+	public function check() : void {
+		throw new EscapeProcessException('Run once proc control driver configured.');
+	}
 
+	public function throwSignalExceptions(bool $throw = true) : void { /* Ignored */ }
 }

--- a/src/Driver/RunOnceProcessDriver.php
+++ b/src/Driver/RunOnceProcessDriver.php
@@ -10,6 +10,4 @@ class RunOnceProcessDriver implements ProcessControl {
 	public function check() : void {
 		throw new EscapeProcessException('Run once proc control driver configured.');
 	}
-
-	public function throwSignalExceptions(bool $throw = true) : void { /* Ignored */ }
 }

--- a/src/Driver/TtlInstantKillProcessDriver.php
+++ b/src/Driver/TtlInstantKillProcessDriver.php
@@ -2,20 +2,17 @@
 
 namespace Resgen\Common\Proc\Driver;
 
-use Resgen\Common\Proc\ProcessControl;
 use Resgen\Common\Proc\EscapeProcessException;
 
-class TtlInstantKillProcessDriver extends TtlProcessDriver implements ProcessControl
-{
-    use Logs;
+class TtlInstantKillProcessDriver extends TtlProcessDriver {
+	use Logs;
 
-    public function sigHandle()
-    {
-        $this->log()->info('Interrupt signal recieved. Hard exiting.');
+	public function sigHandle(int $signo, mixed $info) {
+		$this->log()->info('Interrupt signal recieved. Hard exiting.');
 
-        $this->interrupt = true;
+		$this->interrupt = true;
 
-        throw new EscapeProcessException('Signal recieved, exiting.');
-    }
+		throw new EscapeProcessException('Signal recieved, exiting.');
+	}
 
 }

--- a/src/ProcessControl.php
+++ b/src/ProcessControl.php
@@ -6,8 +6,4 @@ interface ProcessControl {
 
 	/** Call to check for signal being caught */
 	public function check() : void;
-
-	/** Calling this causes signals to throw a SignalException when the signal arrives */
-	public function throwSignalExceptions(bool $throw = true) : void;
-
 }

--- a/src/ProcessControl.php
+++ b/src/ProcessControl.php
@@ -4,6 +4,10 @@ namespace Resgen\Common\Proc;
 
 interface ProcessControl {
 
-    public function check(): void;
+	/** Call to check for signal being caught */
+	public function check() : void;
+
+	/** Calling this causes signals to throw a SignalException when the signal arrives */
+	public function throwSignalExceptions(bool $throw = true) : void;
 
 }

--- a/src/ProcessControlProvider.php
+++ b/src/ProcessControlProvider.php
@@ -6,45 +6,45 @@ use Exception;
 use Illuminate\Support\ServiceProvider;
 use Resgen\Common\Proc\Driver as Driver;
 
-class ProcessControlProvider extends ServiceProvider
-{
+class ProcessControlProvider extends ServiceProvider {
 
-    private $defaultDrivers = [
-        'ttl'          => Driver\TtlProcessDriver::class,
-        'ttl_hardexit' => Driver\TtlInstantKillProcessDriver::class,
-        'runonce'      => Driver\RunOnceProcessDriver::class,
-        'keepalive'    => Driver\KeepAliveProcessDriver::class,
-    ];
+	/** @var string[] */
+	private $defaultDrivers = [
+        'ttl'           => Driver\TtlProcessDriver::class,
+        'ttl_hardexit'  => Driver\TtlInstantKillProcessDriver::class,
+        'runonce'       => Driver\RunOnceProcessDriver::class,
+        'keepalive'     => Driver\KeepAliveProcessDriver::class,
+	];
 
-    protected $customDrivers = [];
+	/** @var array */
+	protected $customDrivers = [];
 
-    public function register()
-    {
-        $drivers = array_merge($this->customDrivers, $this->defaultDrivers);
+	public function register() {
+		$drivers = array_merge($this->customDrivers, $this->defaultDrivers);
 
-        $this->app->singleton(ProcessControl::class, function() use ($drivers) {
-            $selectedDriver = env('LUMEN_PROC_DRIVER', false);
-            $availableDriverKeys = implode(',', array_keys($drivers));
+		$this->app->singleton(ProcessControl::class, function () use ($drivers) {
+			$selectedDriver         = env('LUMEN_PROC_DRIVER', false);
+			$availableDriverKeys    = implode(',', array_keys($drivers));
 
-            if (!$selectedDriver) {
-                throw new Exception(sprintf(
-                    'env.LUMEN_PROC_DRIVER must be set to use proc control. Available drivers: %s',
-                    $availableDriverKeys
-                ));
-            }
+			if (!$selectedDriver) {
+				throw new Exception(sprintf(
+					'env.LUMEN_PROC_DRIVER must be set to use proc control. Available drivers: %s',
+					$availableDriverKeys
+				));
+			}
 
-            $driver = $drivers[$selectedDriver] ?? false;
+			$driver = $drivers[$selectedDriver] ?? false;
 
-            if (!$driver) {
-                throw new Exception(sprintf(
-                    'Invalid proc ctrl driver: %s. Available drivers: %s',
-                    $selectedDriver,
-                    $availableDriverKeys
-                ));
-            }
+			if (!$driver) {
+				throw new Exception(sprintf(
+					'Invalid proc ctrl driver: %s. Available drivers: %s',
+					$selectedDriver,
+					$availableDriverKeys
+				));
+			}
 
-            return app($driver);
-        });
-    }
+			return app($driver);
+		});
+	}
 
 }

--- a/src/SignalException.php
+++ b/src/SignalException.php
@@ -2,7 +2,6 @@
 
 namespace Resgen\Common\Proc;
 
-use JetBrains\PhpStorm\Pure;
 use Throwable;
 
 class SignalException extends \Exception {
@@ -10,7 +9,6 @@ class SignalException extends \Exception {
 
 	public mixed    $info;
 
-	#[Pure]
 	public function __construct(int $signo, mixed $info, ?Throwable $previous = NULL) {
 		$this->signo    = $signo;
 		$this->info     = $info;

--- a/src/SignalException.php
+++ b/src/SignalException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Resgen\Common\Proc;
+
+use JetBrains\PhpStorm\Pure;
+use Throwable;
+
+class SignalException extends \Exception {
+	public int      $signo;
+
+	public mixed    $info;
+
+	#[Pure]
+	public function __construct(int $signo, mixed $info, ?Throwable $previous = NULL) {
+		$this->signo    = $signo;
+		$this->info     = $info;
+
+		parent::__construct("Posix Signal Caught ($signo)", $signo, $previous);
+	}
+
+}


### PR DESCRIPTION
Adds the (opt-in) option to have the active ProcessControl implementation throw a SignalException when the signal is received. No longer requires ProcessControl::check() to be called regularly.